### PR TITLE
Adding count to the Cart.Icon-Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,3 +391,25 @@ Ultimatly saving some computing power.  Wish I read about this before coding all
 
 
 <br><br>
+
+###  Adding count to the Cart.Icon
+
+<hr>
+
+1.  #####  Initial Approach
+    -  Created a simple count of the items 
+    -  Created an empty array
+    -  Created a for loop to loop over cartItems and extract the quantity  and push to the empty array
+    -  Using reducer to get the total of the array 
+
+    This is working, however in hindsight I might want to be able to use this functionality in the checkout.(still to be built)
+    
+    "If an item should be removed from the cart ( this functionality has not yet been implemented), the number should decrease."
+
+    It would be better if this functionality was in the cart.context.
+    It could also be solved by using the useEffect Hook 
+
+2. #####  Second Attempt - 
+
+
+<br><br>

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Ultimatly saving some computing power.  Wish I read about this before coding all
 <br><br>
 
 
-###  Adding Functionality to the Cart
+###  Adding Basic Functionality to the Cart
 
 <hr>
 
@@ -361,10 +361,10 @@ Ultimatly saving some computing power.  Wish I read about this before coding all
         -  Updated the value to include `cartItems` & `addItemToCart`
 
     -  Created new export `addCartItem` helper funciton;
-        This will be a helper function to see if newly added items exist in the cart already.
-        Therefore will know how to handle the quantity inside in the cart.
-        (i.e. - if product exists in the cart: plus quantity by 1, else add item to the cart)
-        -  
+        -  This will be a helper function to see if newly added items exist in the cart already.
+        -  Therefore will know how to handle the quantity inside in the cart.
+        -  (i.e. - if product exists in the cart: plus quantity by 1, else add item to the cart)
+
 
 3.  #####  Added CartItem into the Cart-Dropdown component
     -  Imported the `Cart-Item` compnent 
@@ -388,7 +388,6 @@ Ultimatly saving some computing power.  Wish I read about this before coding all
     - In Hindsight I took the above button function and made it a function called `addProductToCart`
     - Then passed it into the onClick Handler
     (better for readability and optimization)
-
 
 
 <br><br>

--- a/README.md
+++ b/README.md
@@ -408,8 +408,24 @@ Ultimatly saving some computing power.  Wish I read about this before coding all
 
     It would be better if this functionality was in the cart.context.
     It could also be solved by using the useEffect Hook 
+    Back to the drawing board - lets undo this messy approach.  
 
-2. #####  Second Attempt - 
+2. #####  Second Attempt - using useEffect 
+    Because we are recounting the total quantity every time the `cartItems` changes, it makes sense to use the useEffect Hook.  
+    - Imported useEffect
+    - Added `cartItemCount` (default 0) to CartContext
+    - Added `[cartItemCount, setCartItemCount] = useState(0);`
 
+    -  Using the useEffect 
+        - dependancy = `[cartItems]`
+        - created `count` using the reduce method
+        - `total` + `cartItem.quantity`
+        - `setCartItemCount` using the `count` funciton 
+    
+    - Added the `cartItemCount` to the value to be passed into the provider
+
+3.  #####  Finally, adding the `cartItemCount` to Cart.Icon
+    -  Added `carItemCount` via destructuring 
+    -  Using the above in the span inside the `ShoppingIcon`
 
 <br><br>

--- a/src/Components/cart-icon/cart-icon.component.jsx
+++ b/src/Components/cart-icon/cart-icon.component.jsx
@@ -6,15 +6,24 @@ import { CartContext } from '../../contexts/cart.context';
 import './cart-icon.styles.scss';
 
 const CartIcon = () => {
-    
-    const { isCartOpen, setIsCartOpen } = useContext(CartContext);
-
+    const { isCartOpen, setIsCartOpen, cartItems, addCartItem} = useContext(CartContext);
     const toggleIsCartOpen = () => setIsCartOpen(!isCartOpen);
-    
+
+    const totalNumberItemsFunc = ( cartItems ) => {
+      const l= cartItems.length;
+      const cartTotalItems = [];
+      
+      for (let i = 0; i < l ; i++) {
+        cartTotalItems.push(cartItems[i].quantity)
+      };
+      return cartTotalItems.reduce((a,b) => a + b, 0);
+    };
+
     return (
     <div className='cart-icon-container' onClick={toggleIsCartOpen}>
       <ShoppingIcon className='shopping-icon' />
-      <span className='item-count'>0</span>
+      <span className='item-count'>{totalNumberItemsFunc(cartItems)}</span>
+      
     </div>
   );
 };

--- a/src/Components/cart-icon/cart-icon.component.jsx
+++ b/src/Components/cart-icon/cart-icon.component.jsx
@@ -6,24 +6,14 @@ import { CartContext } from '../../contexts/cart.context';
 import './cart-icon.styles.scss';
 
 const CartIcon = () => {
-    const { isCartOpen, setIsCartOpen, cartItems, addCartItem} = useContext(CartContext);
-    const toggleIsCartOpen = () => setIsCartOpen(!isCartOpen);
+  const { isCartOpen, setIsCartOpen, cartItemCount } = useContext(CartContext);
 
-    const totalNumberItemsFunc = ( cartItems ) => {
-      const l= cartItems.length;
-      const cartTotalItems = [];
-      
-      for (let i = 0; i < l ; i++) {
-        cartTotalItems.push(cartItems[i].quantity)
-      };
-      return cartTotalItems.reduce((a,b) => a + b, 0);
-    };
+  const toggleIsCartOpen = () => setIsCartOpen(!isCartOpen);
 
-    return (
+  return (
     <div className='cart-icon-container' onClick={toggleIsCartOpen}>
       <ShoppingIcon className='shopping-icon' />
-      <span className='item-count'>{totalNumberItemsFunc(cartItems)}</span>
-      
+      <span className='item-count'>{cartItemCount}</span>
     </div>
   );
 };

--- a/src/contexts/cart.context.jsx
+++ b/src/contexts/cart.context.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react';
+import { createContext, useState, useEffect } from 'react';
 
 
 
@@ -29,6 +29,7 @@ export const CartContext = createContext({
   setIsOpen: () => {},
   cartItems: [],
   addItemToCart: () => {},
+  cartItemCount: 0,
 });
 
 
@@ -37,11 +38,26 @@ export const CartContext = createContext({
 export const CartProvider = ({ children }) => {
   const [isCartOpen, setIsCartOpen] = useState(false);
   const [cartItems, setCartItems] = useState([]);
+  const [cartItemCount, setCartItemCount] = useState(0);
+
+  useEffect(() => {
+    const count = cartItems.reduce(
+      (total, cartItem) => total + cartItem.quantity,
+      0
+    );
+    setCartItemCount(count);
+  }, [cartItems]);
 
   const addItemToCart = (product) =>
     setCartItems(addCartItem(cartItems, product));
 
-  const value = { isCartOpen, setIsCartOpen, cartItems, addItemToCart };
+    const value = {
+      isCartOpen,
+      setIsCartOpen,
+      cartItems,
+      addItemToCart,
+      cartItemCount,
+    };
 
   return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
 };

--- a/src/contexts/cart.context.jsx
+++ b/src/contexts/cart.context.jsx
@@ -29,7 +29,7 @@ export const CartContext = createContext({
   setIsOpen: () => {},
   cartItems: [],
   addItemToCart: () => {},
-  cartItemCount: 0,
+  cartItemCount: 0, 
 });
 
 
@@ -40,6 +40,8 @@ export const CartProvider = ({ children }) => {
   const [cartItems, setCartItems] = useState([]);
   const [cartItemCount, setCartItemCount] = useState(0);
 
+
+  //  Updating the cart count (total items in the cart)
   useEffect(() => {
     const count = cartItems.reduce(
       (total, cartItem) => total + cartItem.quantity,
@@ -48,6 +50,7 @@ export const CartProvider = ({ children }) => {
     setCartItemCount(count);
   }, [cartItems]);
 
+  //  Adding items to the cart
   const addItemToCart = (product) =>
     setCartItems(addCartItem(cartItems, product));
 


### PR DESCRIPTION
###  Adding count to the Cart.Icon

<hr>

1.  #####  Initial Approach
    -  Created a simple count of the items 
    -  Created an empty array
    -  Created a for loop to loop over cartItems and extract the quantity  and push to the empty array
    -  Using reducer to get the total of the array 

    This is working, however in hindsight I might want to be able to use this functionality in the checkout.(still to be built)
    
    "If an item should be removed from the cart ( this functionality has not yet been implemented), the number should decrease."

    It would be better if this functionality was in the cart.context.
    It could also be solved by using the useEffect Hook 
    Back to the drawing board - lets undo this messy approach. 

<hr> 

2. #####  Second Attempt - using useEffect 
    Because we are recounting the total quantity every time the `cartItems` changes, it makes sense to use the useEffect Hook.  
    - Imported useEffect
    - Added `cartItemCount` (default 0) to CartContext
    - Added `[cartItemCount, setCartItemCount] = useState(0);`

    -  Using the useEffect 
        - dependancy = `[cartItems]`
        - created `count` using the reduce method
        - `total` + `cartItem.quantity`
        - `setCartItemCount` using the `count` funciton 
    
    - Added the `cartItemCount` to the value to be passed into the provider

3.  #####  Finally, adding the `cartItemCount` to Cart.Icon
    -  Added `carItemCount` via destructuring 
    -  Using the above in the span inside the `ShoppingIcon`
